### PR TITLE
[main@b71efc8] Update AL-Go System Files from microsoft/AL-Go-PTE@preview - 1ee4778 / Related to AB#539394

### DIFF
--- a/.github/AL-Go-Settings.json
+++ b/.github/AL-Go-Settings.json
@@ -87,7 +87,7 @@
     ]
   },
   "UpdateALGoSystemFilesEnvironment": "Official-Build",
-  "templateSha": "5c503074c0e7d924a9ee68abd4bb08c8b18921cd",
+  "templateSha": "1ee47784d064e41a0e2fafc9fe6574bc36b8706f",
   "commitOptions": {
     "messageSuffix": "Related to AB#539394",
     "pullRequestAutoMerge": true,

--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -2,8 +2,31 @@
 
 Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.
 
+### Security
+
+- Add top-level permissions for _Increment Version Number_ workflow
+
 ### Issues
 
+- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners
+
+### Test settings against a JSON schema
+
+AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:
+
+```
+"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
+```
+
+### Failing pull requests if new warnings are added
+
+By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.
+
+## v7.1
+
+### Issues
+
+- Issue 1678 Test summary is showing too many status icons
 - Issue 1640 AL1040 error due to app folder within the artifacts cache being incorrectly recognized as an app folder
 - Issue 1630 Error when downloading a release, when the destination folder already exists.
 - Issue 1540 and 1649 Apps with dependencies to Microsft\_\_EXCLUDE\_ apps fails deployment
@@ -13,6 +36,7 @@ Note that when using the preview version of AL-Go for GitHub, we recommend you U
 - Issue 1657 When no files modified on Git, deployment fails
 - Issue 1530 Dependency Field Service Integration does not get published in container while Installing apps
 - Issue 1644 Support for AppAuth when using a private Template repository from another organization
+- Issue 1669 GitHub App authentication to download dependencies from private repositories
 - Issue 1478 Rate Limit Exceeded when running Update AL-Go System files
 
 ## v7.0

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -48,7 +48,7 @@ jobs:
       powerPlatformSolutionFolder: ${{ steps.DeterminePowerPlatformSolutionFolder.outputs.powerPlatformSolutionFolder }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
@@ -59,13 +59,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           get: type,powerPlatformSolutionFolder,useGitSubmodules
@@ -73,7 +73,7 @@ jobs:
       - name: Read submodules token
         id: ReadSubmodulesToken
         if: env.useGitSubmodules != 'false' && env.useGitSubmodules != ''
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -94,7 +94,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Determine Delivery Target Secrets
         id: DetermineDeliveryTargetSecrets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           projectsJson: '${{ steps.determineProjectsToBuild.outputs.ProjectsJson }}'
@@ -115,7 +115,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -123,7 +123,7 @@ jobs:
 
       - name: Determine Delivery Targets
         id: DetermineDeliveryTargets
-        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineDeliveryTargets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -133,7 +133,7 @@ jobs:
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,21 +149,21 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           get: templateUrl
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: 'ghTokenWorkflow'
 
       - name: Check for updates to AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -243,7 +243,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
@@ -252,7 +252,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           artifacts: '.artifacts'
@@ -289,7 +289,7 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           get: type,powerPlatformSolutionFolder
@@ -303,7 +303,7 @@ jobs:
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ matrix.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -311,7 +311,7 @@ jobs:
 
       - name: Deploy to Business Central
         id: Deploy
-        uses: microsoft/AL-Go/Actions/Deploy@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/Deploy@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -323,7 +323,7 @@ jobs:
 
       - name: Deploy to Power Platform
         if: env.type == 'PTE' && env.powerPlatformSolutionFolder != ''
-        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DeployPowerPlatform@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -351,20 +351,20 @@ jobs:
           path: '.artifacts'
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
           getSecrets: '${{ matrix.deliveryTarget }}Context'
 
       - name: Deliver
-        uses: microsoft/AL-Go/Actions/Deliver@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/Deliver@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -384,7 +384,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/DeployReferenceDocumentation.yaml
+++ b/.github/workflows/DeployReferenceDocumentation.yaml
@@ -30,18 +30,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Determine Deployment Environments
         id: DetermineDeploymentEnvironments
-        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineDeploymentEnvironments@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -54,7 +54,7 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build Reference Documentation
-        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/BuildReferenceDocumentation@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           artifacts: 'latest'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -34,6 +34,9 @@ env:
   ALGoOrgSettings: ${{ vars.ALGoOrgSettings }}
   ALGoRepoSettings: ${{ vars.ALGoRepoSettings }}
 
+permissions:
+  contents: read
+
 jobs:
   IncrementVersionNumber:
     needs: [ ]
@@ -45,7 +48,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
@@ -54,18 +57,18 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -73,7 +76,7 @@ jobs:
           useGhTokenWorkflowForPush: '${{ github.event.inputs.useGhTokenWorkflow }}'
 
       - name: Increment Version Number
-        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/IncrementVersionNumber@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           token: ${{ steps.ReadSecrets.outputs.TokenForPush }}
@@ -84,7 +87,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/PullRequestHandler.yaml
+++ b/.github/workflows/PullRequestHandler.yaml
@@ -28,7 +28,7 @@ jobs:
     if: (github.event.pull_request.base.repo.full_name != github.event.pull_request.head.repo.full_name) && (github.event_name != 'pull_request')
     runs-on: windows-latest
     steps:
-      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+      - uses: microsoft/AL-Go/Actions/VerifyPRChanges@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
 
   Initialization:
     needs: [ PregateCheck ]
@@ -45,7 +45,7 @@ jobs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
@@ -57,13 +57,13 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           get: shortLivedArtifactsRetentionDays
@@ -76,7 +76,7 @@ jobs:
 
       - name: Determine Projects To Build
         id: determineProjectsToBuild
-        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineProjectsToBuild@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           maxBuildDepth: ${{ env.workflowDepth }}
@@ -139,7 +139,7 @@ jobs:
     steps:
       - name: Pull Request Status Check
         id: PullRequestStatusCheck
-        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/PullRequestStatusCheck@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -147,7 +147,7 @@ jobs:
 
       - name: Finalize the workflow
         id: PostProcess
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: success() || failure()
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/Troubleshooting.yaml
+++ b/.github/workflows/Troubleshooting.yaml
@@ -30,7 +30,7 @@ jobs:
           lfs: true
 
       - name: Troubleshooting
-        uses: microsoft/AL-Go/Actions/Troubleshooting@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/Troubleshooting@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}

--- a/.github/workflows/UpdateGitHubGoSystemFiles.yaml
+++ b/.github/workflows/UpdateGitHubGoSystemFiles.yaml
@@ -48,14 +48,14 @@ jobs:
 
       - name: Read settings
         id: ReadSettings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           get: templateUrl
 
       - name: Get Workflow Multi-Run Branches
         id: GetBranches
-        uses: microsoft/AL-Go/Actions/GetWorkflowMultiRunBranches@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/GetWorkflowMultiRunBranches@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           includeBranches: ${{ github.event.inputs.includeBranches }}
@@ -77,7 +77,7 @@ jobs:
     name: "[${{ matrix.branch }}] Update AL-Go System Files"
     environment: Official-Build
     needs: [ Initialize ]
-    runs-on: [ windows-latest ]
+    runs-on: windows-latest
     strategy:
       matrix:
         branch: ${{ fromJson(needs.Initialize.outputs.UpdateBranches).branches }}
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Dump Workflow Information
-        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DumpWorkflowInfo@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
@@ -96,19 +96,19 @@ jobs:
 
       - name: Initialize the workflow
         id: init
-        uses: microsoft/AL-Go/Actions/WorkflowInitialize@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowInitialize@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           get: commitOptions
 
       - name: Read secrets
         id: ReadSecrets
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: powershell
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -135,7 +135,7 @@ jobs:
           Add-Content -Encoding UTF8 -Path $env:GITHUB_ENV -Value "downloadLatest=$downloadLatest"
 
       - name: Update AL-Go system files
-        uses: microsoft/AL-Go/Actions/CheckForUpdates@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/CheckForUpdates@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finalize the workflow
         if: always()
-        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/WorkflowPostProcess@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/_BuildALGoProject.yaml
+++ b/.github/workflows/_BuildALGoProject.yaml
@@ -99,7 +99,7 @@ jobs:
           lfs: true
 
       - name: Read settings
-        uses: microsoft/AL-Go/Actions/ReadSettings@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSettings@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Determine whether to build project
         id: DetermineBuildProject
-        uses: microsoft/AL-Go/Actions/DetermineBuildProject@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineBuildProject@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           skippedProjectsJson: ${{ inputs.skippedProjectsJson }}
@@ -118,7 +118,7 @@ jobs:
       - name: Read secrets
         id: ReadSecrets
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && github.event_name != 'pull_request'
-        uses: microsoft/AL-Go/Actions/ReadSecrets@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/ReadSecrets@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           gitHubSecrets: ${{ toJson(secrets) }}
@@ -136,7 +136,7 @@ jobs:
       - name: Determine ArtifactUrl
         id: determineArtifactUrl
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DetermineArtifactUrl@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -151,7 +151,7 @@ jobs:
       - name: Download Project Dependencies
         id: DownloadProjectDependencies
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/DownloadProjectDependencies@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
         with:
@@ -162,7 +162,7 @@ jobs:
           baselineWorkflowRunId: ${{ inputs.baselineWorkflowRunId }}
 
       - name: Build
-        uses: microsoft/AL-Go/Actions/RunPipeline@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/RunPipeline@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True'
         env:
           Secrets: '${{ steps.ReadSecrets.outputs.Secrets }}'
@@ -180,7 +180,7 @@ jobs:
       - name: Sign
         id: sign
         if: steps.DetermineBuildProject.outputs.BuildIt == 'True' && inputs.signArtifacts && env.doNotSignApps == 'False' && (env.keyVaultCodesignCertificateName != '' || (fromJson(env.trustedSigning).Endpoint != '' && fromJson(env.trustedSigning).Account != '' && fromJson(env.trustedSigning).CertificateProfile != ''))
-        uses: microsoft/AL-Go/Actions/Sign@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/Sign@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           azureCredentialsJson: '${{ fromJson(steps.ReadSecrets.outputs.Secrets).AZURE_CREDENTIALS }}'
@@ -188,7 +188,7 @@ jobs:
 
       - name: Calculate Artifact names
         id: calculateArtifactsNames
-        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/CalculateArtifactNames@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         if: success() || failure()
         with:
           shell: ${{ inputs.shell }}
@@ -273,8 +273,8 @@ jobs:
 
       - name: Analyze Test Results
         id: analyzeTestResults
-        if: (success() || failure()) && env.doNotRunTests == 'False' && ((hashFiles(format('{0}/.buildartifacts/TestResults.xml',inputs.project)) != '') || (hashFiles(format('{0}/.buildartifacts/bcptTestResults.json',inputs.project)) != ''))
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        if: (success() || failure()) && env.doNotRunTests == 'False'
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -283,7 +283,7 @@ jobs:
       - name: Analyze BCPT Test Results
         id: analyzeTestResultsBCPT
         if: (success() || failure()) && env.doNotRunBcptTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -292,7 +292,7 @@ jobs:
       - name: Analyze Page Scripting Test Results
         id: analyzeTestResultsPageScripting
         if: (success() || failure()) && env.doNotRunpageScriptingTests == 'False'
-        uses: microsoft/AL-Go/Actions/AnalyzeTests@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/AnalyzeTests@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Cleanup
         if: always() && steps.DetermineBuildProject.outputs.BuildIt == 'True'
-        uses: microsoft/AL-Go/Actions/PipelineCleanup@5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba
+        uses: microsoft/AL-Go/Actions/PipelineCleanup@744b428d8ef042ad2ef43a93a69e22dd5a0816a4
         with:
           shell: ${{ inputs.shell }}
           project: ${{ inputs.project }}

--- a/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Business Foundation/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Performance Toolkit/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Modules/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests (No Isolation)/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application Tests/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/System Application/.AL-Go/localDevEnv.ps1
+++ b/build/projects/System Application/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/cloudDevEnv.ps1
@@ -42,9 +42,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local

--- a/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
+++ b/build/projects/Test Stability Tools/.AL-Go/localDevEnv.ps1
@@ -46,9 +46,9 @@ Write-Host -ForegroundColor Yellow @'
 
 $tmpFolder = Join-Path ([System.IO.Path]::GetTempPath()) "$([Guid]::NewGuid().ToString())"
 New-Item -Path $tmpFolder -ItemType Directory -Force | Out-Null
-$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Github-Helper.psm1' -folder $tmpFolder
-$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
-DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/5cfd7e2ceab0ade7a7b6e46a59a25cd49d3ff3ba/Actions/Packages.json' -folder $tmpFolder | Out-Null
+$GitHubHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Github-Helper.psm1' -folder $tmpFolder
+$ALGoHelperPath = DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/AL-Go-Helper.ps1' -folder $tmpFolder
+DownloadHelperFile -url 'https://raw.githubusercontent.com/microsoft/AL-Go/744b428d8ef042ad2ef43a93a69e22dd5a0816a4/Actions/Packages.json' -folder $tmpFolder | Out-Null
 
 Import-Module $GitHubHelperPath
 . $ALGoHelperPath -local


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, we recommend you Update your AL-Go system files, as soon as possible when informed that an update is available.

### Security

- Add top-level permissions for _Increment Version Number_ workflow

### Issues

- Issue 1697 Error in CheckForUpdates: "Internet Explorer engine is not available" when using self-hosted runners

### Test settings against a JSON schema

AL-Go for GitHub settings now has a schema. The following line is added at the beginning to any AL-Go settings files to utilize the schema:

```
"$schema": "https://raw.githubusercontent.com/microsoft/AL-Go-Actions/<version>/Actions/settings.schema.json"
```

### Failing pull requests if new warnings are added

By setting failOn to 'newWarning', pull requests will fail if new warnings are introduced. This feature compares the warnings in the pull request build against those in the latest successful CI/CD build and fails if new warnings are detected.

## v7.1

### Issues

- Issue 1678 Test summary is showing too many status icons
- Issue 1640 AL1040 error due to app folder within the artifacts cache being incorrectly recognized as an app folder
- Issue 1630 Error when downloading a release, when the destination folder already exists.
- Issue 1540 and 1649 Apps with dependencies to Microsft\_\_EXCLUDE\_ apps fails deployment
- Issue 1547 Dependencies will be installed even if DependencyInstallMode is ignore, but dependencies will never be installed on production environments
- Issue 1654 GithubPackageContext does not work together with private trustedNuGetFeeds
- Issue 1627 AL-Go should throw an error or a warning if you create a release, which is older than the latest release
- Issue 1657 When no files modified on Git, deployment fails
- Issue 1530 Dependency Field Service Integration does not get published in container while Installing apps
- Issue 1644 Support for AppAuth when using a private Template repository from another organization
- Issue 1669 GitHub App authentication to download dependencies from private repositories
- Issue 1478 Rate Limit Exceeded when running Update AL-Go System files

Related to AB#539394